### PR TITLE
Update opencensus

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -190,9 +190,9 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
   name = "go.opencensus.io"
   packages = [
+    ".",
     "exporter/jaeger",
     "exporter/jaeger/internal/gen-go/jaeger",
     "exporter/prometheus",
@@ -209,7 +209,8 @@
     "trace/internal",
     "trace/propagation"
   ]
-  revision = "ebd8d31470fedf6c27d0e3056653ddff642509b8"
+  revision = "7b558058b7cc960667590e5413ef55157b06652e"
+  version = "v0.15.0"
 
 [[projects]]
   branch = "master"
@@ -250,6 +251,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e9ab02d41923dd1515d1a7469cf82491b40e2486da3b7784965c992161642b58"
+  inputs-digest = "68624a05c67cb517ad0dffea519db57d607368e0acf2a2a287606944ff312396"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,9 +6,9 @@
   name = "github.com/gin-gonic/gin"
   version = "1.2.0"
 
-[[constraint]]
+[[override]]
   name = "go.opencensus.io"
-  branch = "master"
+  version = "0.15.0"
 
 [[constraint]]
   branch = "master"

--- a/http.go
+++ b/http.go
@@ -27,6 +27,6 @@ func HTTPRequestExecutor(clientFactory proxy.HTTPClientFactory) proxy.HTTPReques
 		if _, ok := client.Transport.(*ochttp.Transport); !ok {
 			client.Transport = &ochttp.Transport{Base: client.Transport}
 		}
-		return client.Do(req.WithContext(trace.WithSpan(ctx, fromContext(ctx))))
+		return client.Do(req.WithContext(trace.NewContext(ctx, fromContext(ctx))))
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -23,7 +23,7 @@ func Middleware(name string) proxy.Middleware {
 		}
 		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
 			var span *trace.Span
-			ctx, span = trace.StartSpan(ctx, req.URL.Path)
+			ctx, span = trace.StartSpan(ctx, name)
 			resp, err := next[0](ctx, req)
 
 			if err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -22,9 +22,9 @@ func Middleware(name string) proxy.Middleware {
 			panic(proxy.ErrNotEnoughProxies)
 		}
 		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
-			span := trace.NewSpan(name, fromContext(ctx), trace.StartOptions{})
-
-			resp, err := next[0](trace.WithSpan(ctx, span), req)
+			var span *trace.Span
+			ctx, span = trace.StartSpan(ctx, req.URL.Path)
+			resp, err := next[0](ctx, req)
 
 			if err != nil {
 				if err.Error() != errCtxCanceledMsg {

--- a/proxy.go
+++ b/proxy.go
@@ -22,7 +22,8 @@ func Middleware(name string) proxy.Middleware {
 			panic(proxy.ErrNotEnoughProxies)
 		}
 		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
-			ctx, span := trace.StartSpan(trace.NewContext(ctx, fromContext(ctx)), name)
+			var span *trace.Span
+			ctx, span = trace.StartSpan(trace.NewContext(ctx, fromContext(ctx)), name)
 			resp, err := next[0](ctx, req)
 
 			if err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -22,8 +22,7 @@ func Middleware(name string) proxy.Middleware {
 			panic(proxy.ErrNotEnoughProxies)
 		}
 		return func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
-			var span *trace.Span
-			ctx, span = trace.StartSpan(ctx, name)
+			ctx, span := trace.StartSpan(trace.NewContext(ctx, fromContext(ctx)), name)
 			resp, err := next[0](ctx, req)
 
 			if err != nil {


### PR DESCRIPTION
This changes allows to use an opencensus version greater than 0.8.0.
In 0.9.0 `WithSpan`, `NewSpan` and other methods where changed/removed.