### PR TITLE
Allow prometheus exporter namespace to be configurable.

### DIFF
--- a/exporter/prometheus/prometheus.go
+++ b/exporter/prometheus/prometheus.go
@@ -22,7 +22,13 @@ func Exporter(ctx context.Context, cfg opencensus.Config) (*prometheus.Exporter,
 	if cfg.Exporters.Prometheus == nil {
 		return nil, errDisabled
 	}
-	exporter, err := prometheus.NewExporter(prometheus.Options{})
+
+	ns := "krakend"
+	if cfg.Exporters.Prometheus.Namespace != "" {
+		ns = cfg.Exporters.Prometheus.Namespace
+	}
+
+	exporter, err := prometheus.NewExporter(prometheus.Options{Namespace: ns})
 	if err != nil {
 		return exporter, err
 	}

--- a/exporter/prometheus/prometheus.go
+++ b/exporter/prometheus/prometheus.go
@@ -23,12 +23,7 @@ func Exporter(ctx context.Context, cfg opencensus.Config) (*prometheus.Exporter,
 		return nil, errDisabled
 	}
 
-	ns := "krakend"
-	if cfg.Exporters.Prometheus.Namespace != "" {
-		ns = cfg.Exporters.Prometheus.Namespace
-	}
-
-	exporter, err := prometheus.NewExporter(prometheus.Options{Namespace: ns})
+	exporter, err := prometheus.NewExporter(prometheus.Options{Namespace: cfg.Exporters.Prometheus.Namespace})
 	if err != nil {
 		return exporter, err
 	}

--- a/opencensus.go
+++ b/opencensus.go
@@ -114,7 +114,8 @@ type Config struct {
 			ServiceName string `json:"service_name"`
 		} `json:"jaeger"`
 		Prometheus *struct {
-			Port int `json:"port"`
+			Namespace string `json:"namespace"`
+			Port      int    `json:"port"`
 		} `json:"prometheus"`
 		Logger *struct{} `json:"logger"`
 		Xray   *struct {


### PR DESCRIPTION
Currently the prometheus exporter namespace is empty, which means
metrics are rooted at 'opencensus_io'. This is less than ideal
and currently not configurable. This change proposes adding a new
prometheus exporter configuration param which allows the setting of
a custom namespace. In the event this parameter is not set, the
namespace will default to 'krakend'.