### PR TITLE
Avoid multiple config scanning

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 	krakendgin "github.com/devopsfaith/krakend/router/gin"
 	"github.com/devopsfaith/krakend/transport/http/client"
 	"github.com/gin-gonic/gin"
@@ -77,6 +78,7 @@ func main() {
 		Middlewares:    []gin.HandlerFunc{},
 		Logger:         logger,
 		HandlerFactory: opencensusgin.New(krakendgin.EndpointHandler),
+		RunServer:      router.RunServer,
 	})
 
 	// start the engine

--- a/opencensus.go
+++ b/opencensus.go
@@ -375,7 +375,8 @@ func GetAggregatedPathForBackendMetrics(cfg *config.Backend) func(r *http.Reques
 
 	if aggregationMode == "lastparam" {
 		return func(r *http.Request) string {
-			// only aggregates the last section of the path if it is a parameter, will default to pattern mode if the last part of the url is not a parameter (misconfiguration)
+			// only aggregates the last section of the path if it is a parameter,
+			// will default to pattern mode if the last part of the url is not a parameter (misconfiguration)
 			lastArgument := cfg.URLPattern[strings.LastIndex(cfg.URLPattern, "/")+1:]
 			if len(lastArgument) > 3 && lastArgument[:3] == `{{.` {
 				// lastArgument is a parameter, aggregate and overwrite path

--- a/opencensus_test.go
+++ b/opencensus_test.go
@@ -1,0 +1,98 @@
+package opencensus
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/devopsfaith/krakend/config"
+)
+
+func TestGetAggregatedPathForMetrics(t *testing.T) {
+	for i, tc := range []struct {
+		cfg      config.EndpointConfig
+		expected string
+	}{
+		{
+			cfg:      config.EndpointConfig{Endpoint: "/api/:foo/:bar"},
+			expected: "/api/{foo}/{bar}",
+		},
+		{
+			cfg: config.EndpointConfig{
+				Endpoint: "/api/:foo/:bar",
+				ExtraConfig: config.ExtraConfig{
+					Namespace: map[string]interface{}{"path_aggregation": "pattern"},
+				},
+			},
+			expected: "/api/{foo}/{bar}",
+		},
+		{
+			cfg: config.EndpointConfig{
+				Endpoint: "/api/:foo/:bar",
+				ExtraConfig: config.ExtraConfig{
+					Namespace: map[string]interface{}{"path_aggregation": "lastparam"},
+				},
+			},
+			expected: "/api/foo/{bar}",
+		},
+		{
+			cfg: config.EndpointConfig{
+				Endpoint: "/api/:foo/:bar",
+				ExtraConfig: config.ExtraConfig{
+					Namespace: map[string]interface{}{"path_aggregation": "off"},
+				},
+			},
+			expected: "/api/foo/bar",
+		},
+	} {
+		extractor := GetAggregatedPathForMetrics(&tc.cfg)
+		r, _ := http.NewRequest("GET", "http://example.tld/api/foo/bar", nil)
+		if tag := extractor(r); tag != tc.expected {
+			t.Errorf("tc-%d: unexpected result: %s", i, tag)
+		}
+	}
+}
+
+func TestGetAggregatedPathForBackendMetrics(t *testing.T) {
+	for i, tc := range []struct {
+		cfg      config.Backend
+		expected string
+	}{
+		{
+			cfg:      config.Backend{URLPattern: "/api/{{.Foo}}/{{.Bar}}"},
+			expected: "/api/{foo}/{bar}",
+		},
+		{
+			cfg: config.Backend{
+				URLPattern: "/api/{{.Foo}}/{{.Bar}}",
+				ExtraConfig: config.ExtraConfig{
+					Namespace: map[string]interface{}{"path_aggregation": "pattern"},
+				},
+			},
+			expected: "/api/{foo}/{bar}",
+		},
+		{
+			cfg: config.Backend{
+				URLPattern: "/api/{{.Foo}}/{{.Bar}}",
+				ExtraConfig: config.ExtraConfig{
+					Namespace: map[string]interface{}{"path_aggregation": "lastparam"},
+				},
+			},
+			expected: "/api/foo/{bar}",
+		},
+		{
+			cfg: config.Backend{
+				URLPattern: "/api/{{.Foo}}/{{.Bar}}",
+				ExtraConfig: config.ExtraConfig{
+					Namespace: map[string]interface{}{"path_aggregation": "off"},
+				},
+			},
+			expected: "/api/foo/bar",
+		},
+	} {
+		extractor := GetAggregatedPathForBackendMetrics(&tc.cfg)
+		r, _ := http.NewRequest("GET", "http://example.tld/api/foo/bar", nil)
+		if tag := extractor(r); tag != tc.expected {
+			t.Errorf("tc-%d: unexpected result: %s", i, tag)
+		}
+	}
+}

--- a/router/mux/endpoint.go
+++ b/router/mux/endpoint.go
@@ -21,8 +21,9 @@ func New(hf mux.HandlerFactory) mux.HandlerFactory {
 }
 
 func tagAggregationMiddleware(next http.Handler, cfg *config.EndpointConfig) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ochttp.SetRoute(r.Context(), opencensus.GetAggregatedPathForMetrics(cfg, r))
+	pathExtractor := opencensus.GetAggregatedPathForMetrics(cfg)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ochttp.SetRoute(r.Context(), pathExtractor(r))
 		next.ServeHTTP(w, r)
-    })
+	})
 }


### PR DESCRIPTION
This pr splits the path extractor functions into 2 different stages:
- config scanning
- path normalization

so the endpoint/backend config is parsed just once instead of at every request