### PR TITLE
Fix nil panic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: go
 
 go:
-    - "1.13.x"
-    - "1.12.x"
-    - "1.11.x"
+    - "1.16.x"
+    - "1.15.x"
     
-env:
-    - GO111MODULE=on
-
 script:
     - make

--- a/opencensus.go
+++ b/opencensus.go
@@ -300,6 +300,9 @@ func parseCfg(srvCfg config.ServiceConfig) (*Config, error) {
 
 func parseEndpointConfig(endpointCfg *config.EndpointConfig) (*EndpointExtraConfig, error) {
 	cfg := new(EndpointExtraConfig)
+	if endpointCfg == nil && endpointCfg.ExtraConfig == nil {
+		return nil, errNoExtraConfig
+	}
 	tmp, ok := endpointCfg.ExtraConfig[Namespace]
 	if !ok {
 		return nil, errNoExtraConfig
@@ -312,9 +315,12 @@ func parseEndpointConfig(endpointCfg *config.EndpointConfig) (*EndpointExtraConf
 	return cfg, nil
 }
 
-func parseBackendConfig(endpointCfg *config.Backend) (*EndpointExtraConfig, error) {
+func parseBackendConfig(backendCfg *config.Backend) (*EndpointExtraConfig, error) {
 	cfg := new(EndpointExtraConfig)
-	tmp, ok := endpointCfg.ExtraConfig[Namespace]
+	if backendCfg == nil && backendCfg.ExtraConfig == nil {
+		return nil, errNoExtraConfig
+	}
+	tmp, ok := backendCfg.ExtraConfig[Namespace]
 	if !ok {
 		return nil, errNoExtraConfig
 	}

--- a/opencensus.go
+++ b/opencensus.go
@@ -300,7 +300,7 @@ func parseCfg(srvCfg config.ServiceConfig) (*Config, error) {
 
 func parseEndpointConfig(endpointCfg *config.EndpointConfig) (*EndpointExtraConfig, error) {
 	cfg := new(EndpointExtraConfig)
-	if endpointCfg == nil && endpointCfg.ExtraConfig == nil {
+	if endpointCfg == nil || endpointCfg.ExtraConfig == nil {
 		return nil, errNoExtraConfig
 	}
 	tmp, ok := endpointCfg.ExtraConfig[Namespace]
@@ -317,7 +317,7 @@ func parseEndpointConfig(endpointCfg *config.EndpointConfig) (*EndpointExtraConf
 
 func parseBackendConfig(backendCfg *config.Backend) (*EndpointExtraConfig, error) {
 	cfg := new(EndpointExtraConfig)
-	if backendCfg == nil && backendCfg.ExtraConfig == nil {
+	if backendCfg == nil || backendCfg.ExtraConfig == nil {
 		return nil, errNoExtraConfig
 	}
 	tmp, ok := backendCfg.ExtraConfig[Namespace]


### PR DESCRIPTION
this pr checks if the configuration is nil before accessing it, avoiding panics.