### PR TITLE
Auto-detect resource in stackdriver exporter

### DIFF
--- a/exporter/stackdriver/stackdriver.go
+++ b/exporter/stackdriver/stackdriver.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
 	opencensus "github.com/devopsfaith/krakend-opencensus"
 )
 
@@ -36,5 +37,6 @@ func Exporter(ctx context.Context, cfg opencensus.Config) (*stackdriver.Exporter
 		BundleDelayThreshold:    time.Duration(cfg.ReportingPeriod) * time.Second,
 		BundleCountThreshold:    cfg.SampleRate,
 		DefaultMonitoringLabels: labels,
+		MonitoredResource:       monitoredresource.Autodetect(),
 	})
 }


### PR DESCRIPTION
I realized the exporter constructor doesn't automatically detect self by default, even in GCE/GKE/EC2 environments

By the fact:
> Stackdriver Monitoring only allows a single writer per TimeSeries

https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/42e7e58efdb937e8477f827d3fba022212335dbc/stackdriver.go#L161-L163
it will often produce errors in a cluster deployment, regarding time series points not being written in order (as in https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/issues/263) because it cannot distinguish reports from different nodes with same configuration (i.e. reporting interval, labels)

The issue could be resolved by auto-detecting the monitored resource and specifying it explicitly. Outside these contexts, it will just fallback to the global resource type, without problem.